### PR TITLE
binding.pryに対応しました。使用方法はREADME.mdに追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ docker-compose build --no-cache
 docker-compose up -d
 ##  railsコンテナに入る場合
 docker-compose exec web /bin/bash
+
+##  binding.pryを使用する場合
+docker attach back_end_web_1
+back_end_web_1はコンテナ名
+Macならcontinueと入力した後Ctrl+p+qで抜けられます。
 ##  終了時
 docker-compose down
 #  frontend

--- a/back_end/Gemfile
+++ b/back_end/Gemfile
@@ -37,6 +37,7 @@ end
 
 group :development do
   gem 'listen', '>= 3.0.5', '< 3.2'
+  gem 'pry-byebug'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'

--- a/back_end/Gemfile.lock
+++ b/back_end/Gemfile.lock
@@ -42,6 +42,7 @@ GEM
     bcrypt (3.1.16)
     builder (3.2.4)
     byebug (11.1.3)
+    coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     diff-lcs (1.4.4)
@@ -74,6 +75,12 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     puma (3.12.6)
     rack (2.2.3)
     rack-cors (1.1.1)
@@ -154,6 +161,7 @@ DEPENDENCIES
   jwt
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.3.18, < 0.6.0)
+  pry-byebug
   puma (~> 3.7)
   rack-cors
   rails (~> 5.1.6)

--- a/back_end/app/controllers/api/v1/hello_controller.rb
+++ b/back_end/app/controllers/api/v1/hello_controller.rb
@@ -3,6 +3,7 @@ module Api
   module V1
     class HelloController < ApplicationController
       def index
+
         render json: {status:'SUCCESS'}
 
       end

--- a/back_end/docker-compose.yml
+++ b/back_end/docker-compose.yml
@@ -20,6 +20,7 @@ services:
     depends_on:
       - mysql
     tty: true
+    stdin_open: true
     networks: 
       - default
       - shared-network


### PR DESCRIPTION
目的
railsででバックができるように対応
達成条件
binding.pryでデバッグができます。
実装の概要
docker-composeとGemfileを変更したのでdocker-compose buildをする必要があるかもしれません。
