### PR TITLE
ログイン・登録に成功した際に遷移を行うことによりtokenの破壊を防ぐ

### DIFF
--- a/front_end/app/src/actions/authAction.js
+++ b/front_end/app/src/actions/authAction.js
@@ -26,7 +26,7 @@ export const loginRequest = () => ({
 export const LOGIN_SUCCESS = 'LOGIN_SUCCESS';
 export const loginSuccess = (token) => ({
   type: LOGIN_SUCCESS,
-  token: token,
+  token,
   receivedAt: Date.now(),
 });
 
@@ -44,7 +44,7 @@ export const signupRequest = () => ({
 export const SIGNUP_SUCCESS = 'SIGNUP_SUCCESS';
 export const signupSuccess = (token) => ({
   type: SIGNUP_SUCCESS,
-  token: token,
+  token,
   receivedAt: Date.now(),
 });
 
@@ -69,7 +69,7 @@ export const login = (user, history) => (dispatch) => {
     .then((res) => {
       localStorage.setItem('jwt', res.data.access_token);
       dispatch(loginSuccess(res.data.access_token));
-      history.push("/");
+      history.push('/');
     })
     .catch((err) => dispatch(loginFailure(err)));
 };
@@ -89,7 +89,7 @@ export const signup = (user, history) => (dispatch) => {
     .then((res) => {
       localStorage.setItem('jwt', res.data.access_token);
       dispatch(signupSuccess(res.data.access_token));
-      history.push("/");
+      history.push('/');
     })
     .catch((err) => dispatch(signupFailure(err)));
 };

--- a/front_end/app/src/actions/authAction.js
+++ b/front_end/app/src/actions/authAction.js
@@ -26,7 +26,7 @@ export const loginRequest = () => ({
 export const LOGIN_SUCCESS = 'LOGIN_SUCCESS';
 export const loginSuccess = (token) => ({
   type: LOGIN_SUCCESS,
-  token,
+  token: token,
   receivedAt: Date.now(),
 });
 
@@ -44,7 +44,7 @@ export const signupRequest = () => ({
 export const SIGNUP_SUCCESS = 'SIGNUP_SUCCESS';
 export const signupSuccess = (token) => ({
   type: SIGNUP_SUCCESS,
-  token,
+  token: token,
   receivedAt: Date.now(),
 });
 
@@ -61,13 +61,15 @@ export const signupFailure = (error) => ({
  * @param {Object} user - ログインに必要なデータが格納されている
  * @param {string} user.name - ユーザー名
  * @param {string} user.password - パスワード
+ * @param {function} history - ログイン後に遷移を管理する関数
  */
-export const login = (user) => (dispatch) => {
+export const login = (user, history) => (dispatch) => {
   dispatch(loginRequest());
   return axios.post('http://localhost:8000/auth/login', user)
     .then((res) => {
       localStorage.setItem('jwt', res.data.access_token);
-      dispatch(loginSuccess(res.data));
+      dispatch(loginSuccess(res.data.access_token));
+      history.push("/");
     })
     .catch((err) => dispatch(loginFailure(err)));
 };
@@ -79,13 +81,15 @@ export const login = (user) => (dispatch) => {
  * @param {Object} user - ログインに必要なデータが格納されている
  * @param {string} user.name - ユーザー名
  * @param {string} user.password - パスワード
+ * @param {function} history - ログイン後に遷移を管理する関数
  */
-export const signup = (user) => (dispatch) => {
+export const signup = (user, history) => (dispatch) => {
   dispatch(signupRequest());
   return axios.post('http://localhost:8000/auth/signup', user)
     .then((res) => {
       localStorage.setItem('jwt', res.data.access_token);
-      dispatch(signupSuccess(res.data));
+      dispatch(signupSuccess(res.data.access_token));
+      history.push("/");
     })
     .catch((err) => dispatch(signupFailure(err)));
 };
@@ -94,9 +98,10 @@ export const signup = (user) => (dispatch) => {
  * 画面がリロードされた際に、localstrageからログイン情報を取得する
  * jwtの取得の可否に応じてstateを更新する
  */
-export const reload = (jwt) => (dispatch) => {
+export const reload = () => (dispatch) => {
   dispatch(reloadRequest());
-
+  const jwt = localStorage.getItem('jwt');
+  console.log(jwt);
   if (jwt !== null) dispatch(reloadSuccess(jwt));
   else dispatch(reloadFailure('cannot load jwt token'));
 };

--- a/front_end/app/src/components/auth/auth.js
+++ b/front_end/app/src/components/auth/auth.js
@@ -27,10 +27,10 @@ const Auth = (props) => {
   const history = useHistory();
   const dispatch = useDispatch();
 
-  const jwt = localStorage.getItem('jwt');
 
   useEffect(() => {
-    dispatch(reload(jwt));
+    dispatch(reload());
+    console.log(auth);
   }, []);
 
   if (!auth.isLoading && !auth.isLoggedIn) {

--- a/front_end/app/src/components/auth/auth.js
+++ b/front_end/app/src/components/auth/auth.js
@@ -27,7 +27,6 @@ const Auth = (props) => {
   const history = useHistory();
   const dispatch = useDispatch();
 
-
   useEffect(() => {
     dispatch(reload());
     console.log(auth);

--- a/front_end/app/src/components/auth/signin.js
+++ b/front_end/app/src/components/auth/signin.js
@@ -10,8 +10,8 @@ import Button from '@material-ui/core/Button';
 import { makeStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import AccountCircle from '@material-ui/icons/AccountCircle';
-import { login } from '../../actions/authAction';
 import { useHistory } from 'react-router-dom';
+import { login } from '../../actions/authAction';
 
 const useStyles = makeStyles(() => ({
   textBox: {

--- a/front_end/app/src/components/auth/signin.js
+++ b/front_end/app/src/components/auth/signin.js
@@ -11,6 +11,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import Paper from '@material-ui/core/Paper';
 import AccountCircle from '@material-ui/icons/AccountCircle';
 import { login } from '../../actions/authAction';
+import { useHistory } from 'react-router-dom';
 
 const useStyles = makeStyles(() => ({
   textBox: {
@@ -33,6 +34,7 @@ const Signin = () => {
   const classes = useStyles();
   const { register, handleSubmit } = useForm();
   const dispatch = useDispatch();
+  const history = useHistory();
 
   /**
    * フォームのログインボタンがクリックされた際に発火する
@@ -43,7 +45,7 @@ const Signin = () => {
    */
   const Submit = (data) => {
     // jsonデータに変形してから投げる
-    dispatch(login(JSON.stringify(data)));
+    dispatch(login(JSON.stringify(data), history));
   };
 
   return (

--- a/front_end/app/src/components/auth/signup.js
+++ b/front_end/app/src/components/auth/signup.js
@@ -4,6 +4,7 @@
 import React from 'react';
 import { useDispatch } from 'react-redux';
 import { useForm } from 'react-hook-form';
+import { useHistory } from 'react-router-dom';
 import TextField from '@material-ui/core/TextField';
 import Button from '@material-ui/core/Button';
 
@@ -33,6 +34,7 @@ const Signup = () => {
   const classes = useStyles();
   const { register, handleSubmit } = useForm();
   const dispatch = useDispatch();
+  const history = useHistory();
 
   /**
    * フォームの登録ボタンがクリックされた際に発火する
@@ -43,7 +45,7 @@ const Signup = () => {
    */
   const Submit = (data) => {
     // jsonデータに変形してから投げる
-    dispatch(signup(JSON.stringify(data)));
+    dispatch(signup(JSON.stringify(data), history));
   };
 
   return (

--- a/front_end/app/src/reducers/authReducer.js
+++ b/front_end/app/src/reducers/authReducer.js
@@ -22,7 +22,7 @@ const auth = (state = initialState, action) => {
       };
     case SIGNUP_SUCCESS:
       return {
-        token: action.token.access_token,
+        token: action.token,
         isLoggedIn: true,
         isLoading: false,
         lastUpdated: action.receivedAt,
@@ -42,7 +42,7 @@ const auth = (state = initialState, action) => {
       };
     case LOGIN_SUCCESS:
       return {
-        token: action.token.access_token,
+        token: action.token,
         isLoggedIn: true,
         isLoading: false,
         lastUpdated: action.receivedAt,

--- a/front_end/app/src/reducers/authReducer.test.js
+++ b/front_end/app/src/reducers/authReducer.test.js
@@ -43,10 +43,9 @@ describe('auth reducer', () => {
   });
 
   test('should handle SIGNUP_SUCCESS', () => {
-    const accessToken = 'token';
-    const token = { access_token: 'token' };
+    const token = 'token';
     const expectedObject = {
-      token: accessToken,
+      token,
       isLoggedIn: true,
       isLoading: false,
       lastUpdated: Date.now(),
@@ -92,10 +91,9 @@ describe('auth reducer', () => {
   });
 
   test('should handle LOGIN_SUCCESS', () => {
-    const accessToken = 'token';
-    const token = { access_token: 'token' };
+    const token = 'token';
     const expectedObject = {
-      token: accessToken,
+      token,
       isLoggedIn: true,
       isLoading: false,
       lastUpdated: Date.now(),


### PR DESCRIPTION
やったこと
- redux上でのtokenの管理方法を変更
- ログイン・登録が成功した際にメインページに遷移させる部分を実装