### PR TITLE
サインアップ画面のデザインのズレを修正

### DIFF
--- a/front_end/app/src/components/auth/signup.js
+++ b/front_end/app/src/components/auth/signup.js
@@ -88,6 +88,7 @@ const Signup = () => {
         })()}
 
         <form onSubmit={handleSubmit(Submit)}>
+          <div>
           <TextField
             className={classes.textBox}
             name="name"
@@ -95,6 +96,8 @@ const Signup = () => {
             inputRef={register}
             variant="filled"
           />
+          </div>
+          <div>
           <TextField
             className={classes.textBox}
             name="password"
@@ -103,6 +106,8 @@ const Signup = () => {
             inputRef={register}
             variant="filled"
           />
+          </div>
+          <div>
           <TextField
             className={classes.textBox}
             name="anotherPassword"
@@ -111,9 +116,12 @@ const Signup = () => {
             inputRef={register}
             variant="filled"
           />
+          </div>
+          <div>
           <Button className={classes.button} type="submit">
             登録
           </Button>
+          </div>
         </form>
       </Paper>
     </div>


### PR DESCRIPTION
 - やったこと
macのchromeでサインアップ画面を見ると，デザインが崩れてしまう問題を修正．