### PR TITLE
TimeZone日本に変更

### DIFF
--- a/back_end/config/application.rb
+++ b/back_end/config/application.rb
@@ -29,6 +29,7 @@ module Myapp
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    config.time_zone = 'Tokyo' #Hiranuma
     #rikuiwasaki
     config.action_cable.mount_path='/cable'
     config.generators do |g|

--- a/front_end/app/src/components/main/index.js
+++ b/front_end/app/src/components/main/index.js
@@ -99,7 +99,18 @@ export const RoomList = (rooms) => {
                     <img src={`http://img.youtube.com/vi/${room.youtube_id}/mqdefault.jpg`} alt={room.name} />
                     <GridListTileBar
                       title={room.name}
-                      subtitle={room.start_time}
+                      subtitle={(() => {
+                        const time = room.start_time.split(/-+|T+|:+|\.+/);
+                        const year = time[0];
+                        const month = time[1];
+                        const day = time[2];
+                        const hour = time[3];
+                        const minite = time[4];
+                        const date = year + "-" + month + "-" + day + " " + hour + ":" + minite;
+                        return(
+                            date
+                        )
+                      })()}
                       actionIcon={
                         <Button onClick={() => handleClick(index)} variant="contained" className={classes.enterRoom} >入室</Button>
                       }

--- a/front_end/app/src/components/room/room.js
+++ b/front_end/app/src/components/room/room.js
@@ -102,7 +102,19 @@ const Room = () => {
       <Grid container className={classes.grid}>
       <Grid items xs={10}>
       <h4 className={classes.texts}>
-        {room.start_time}
+        Show Time :
+        {(() => {
+          const time = room.start_time.split(/-+|T+|:+|\.+/);
+          const year = time[0];
+          const month = time[1];
+          const day = time[2];
+          const hour = time[3];
+          const minite = time[4];
+          const date = year + "-" + month + "-" + day + " " + hour + ":" + minite;
+          return(
+              " " + date
+          )
+        })()}
       </h4>
       </Grid>
       <Grid items xs={2}>


### PR DESCRIPTION
ルームの表記が日本時間ではなかったため
日本時間に変換して表示
余分な表記を削除して見やすいように変更
<img width="1440" alt="スクリーンショット 2020-09-10 11 33 27" src="https://user-images.githubusercontent.com/68529763/92674997-75126480-f359-11ea-8de8-48a8260fcdfe.png">
<img width="1440" alt="スクリーンショット 2020-09-10 11 33 40" src="https://user-images.githubusercontent.com/68529763/92675018-7c397280-f359-11ea-93ec-5fe9163a84cc.png">

